### PR TITLE
fix  global_costmap/global_frame from '/map' to 'map'

### DIFF
--- a/navigation_stage/move_base_config/global_costmap_params.yaml
+++ b/navigation_stage/move_base_config/global_costmap_params.yaml
@@ -2,7 +2,7 @@
 
 global_costmap:
   #Set the global and robot frames for the costmap
-  global_frame: /map
+  global_frame: map
   robot_base_frame: base_link
 
   #Set the update and publish frequency of the costmap


### PR DESCRIPTION
this outputs following warnings when running `move_base_gmapping_5cm.launch` on melodic

```
Warning: Invalid argument "/map" passed to canTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
Warning: Invalid argument "/map" passed to canTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
Warning: Invalid argument "/map" passed to canTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
Warning: Invalid argument "/map" passed to canTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
Warning: Invalid argument "/map" passed to canTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:
```